### PR TITLE
Remove Float:asCompileString overwrite

### DIFF
--- a/SystemOverwrites/extFloatPostfix.sc
+++ b/SystemOverwrites/extFloatPostfix.sc
@@ -1,7 +1,0 @@
-+ Float {
-	asCompileString {
-		^if (this.frac == 0.0) {
-			this.asString ++ ".0"
-		} { this.asString }
-	}
-}


### PR DESCRIPTION
this breaks in 3.10dev and gives you strings like `"1.0.0"`. not a good idea to overwrite core classes.