### PR TITLE
MFunc: implement .valueArray

### DIFF
--- a/Classes/MFunc.sc
+++ b/Classes/MFunc.sc
@@ -180,6 +180,23 @@ MFunc : AbstractFunction {
 			}
 		};
 	}
+	
+	valueArray { |...args|
+		if (useTry) { ^this.tryValueArray(*args) };
+		^activeFuncs.array.collect(_.valueArray(*args));
+	}
+
+	tryValueArray { |...args|
+		^activeFuncs.array.collect { |func, i|
+			try {
+				func.valueArray(*args)
+			} {
+				"% : .valueArray failed at %: %\n"
+				.postf(this, activeNames[i].cs, func.cs);
+				'__failed__'
+			}
+		};
+	}
 
 	makeExclusiveModes { |name, modeList, modeNames|
 		modeList = modeList ? modeLists[name];


### PR DESCRIPTION
I'd like to trigger an MFunc via a SimpleController, but the latter uses .valueArray instead of .value. This PR adds .valueArray to MFunc.