### PR TITLE
Fix comments

### DIFF
--- a/Classes/extSoundFileFind.sc
+++ b/Classes/extSoundFileFind.sc
@@ -1,37 +1,37 @@
-/*
+
 
 ///// find 4 default sounds in SC resourceDir:
-SoundFile.pathMatch(Platform.resourceDir +/+ "sounds/a11*.aiff");
-SoundFile.pathMatch("~/*/*.*").size;
-SoundFile.pathMatch("~/*/*/*.*").size;
+// SoundFile.pathMatch(Platform.resourceDir +/+ "sounds/a11*.aiff");
+// SoundFile.pathMatch("~/*/*.*").size;
+// SoundFile.pathMatch("~/*/*/*.*").size;
 
 
-// three intended fails:
-SoundFile.exists("nope/no/file/there.wav");
-SoundFile.exists("this/is/a/folder/");
-SoundFile.exists("this/is/a/forbidden.psd");
-// psd open bug says something
-SoundFile.openRead("/Users/adc/Pictures/DragonFyrAll.psd");
-SoundFile.exists("/Users/adc/Pictures/DragonFyrAll.psd");
+////// three intended fails:
+// SoundFile.exists("nope/no/file/there.wav");
+// SoundFile.exists("this/is/a/folder/");
+// SoundFile.exists("this/is/a/forbidden.psd");
+////// psd open bug says something
+// SoundFile.openRead("/Users/adc/Pictures/DragonFyrAll.psd");
+// SoundFile.exists("/Users/adc/Pictures/DragonFyrAll.psd");
 
-// true:
-SoundFile.exists(Platform.resourceDir +/+ "sounds/a11wlk01-44_1.aiff");
+////// true:
+// SoundFile.exists(Platform.resourceDir +/+ "sounds/a11wlk01-44_1.aiff");
 // should not crash (libsndfile bug with old apple resource fork)
-SoundFile.openRead("/Users/adc/Pictures/DragonFyrAll.psd")
-SoundFile.pathMatch("/Users/adc/Pictures/DragonFyrAll.psd")
-SoundFile.pathMatch(Platform.resourceDir +/+ "sounds/a11*.aiff");
-SoundFile.find([Platform.resourceDir +/+ "sounds/a11*.aiff"]).flat;
-SoundFile.find(Platform.resourceDir +/+ "sounds/""*").flat;
+// SoundFile.openRead("/Users/adc/Pictures/DragonFyrAll.psd")
+// SoundFile.pathMatch("/Users/adc/Pictures/DragonFyrAll.psd")
+// SoundFile.pathMatch(Platform.resourceDir +/+ "sounds/a11*.aiff");
+// SoundFile.find([Platform.resourceDir +/+ "sounds/a11*.aiff"]).flat;
+// SoundFile.find(Platform.resourceDir +/+ "sounds/""*").flat;
+//
+// SoundFile.find(Platform.resourceDir +/+ "sounds/""*", { |sf| sf.duration > 1 });
+// SoundFile.find(Platform.resourceDir +/+ "sounds/""*", { |sf| sf.duration <= 1 });
+//
+// SoundFile.find("~/*/*.*").do { |sf| sf.path.basename.postcs };
+////// works with array of paths:
+// SoundFile.find(["~/*/*.wav", "~/*/*.aif"]).do(_.do { |sf| sf.path.basename.postcs });
 
-SoundFile.find(Platform.resourceDir +/+ "sounds/""*", { |sf| sf.duration > 1 });
-SoundFile.find(Platform.resourceDir +/+ "sounds/""*", { |sf| sf.duration <= 1 });
-
-SoundFile.find("~/*/*.*").do { |sf| sf.path.basename.postcs };
-// works with array of paths:
-SoundFile.find(["~/*/*.wav", "~/*/*.aif"]).do(_.do { |sf| sf.path.basename.postcs });
 
 
-*/
 
 + SoundFile {
 


### PR DESCRIPTION
The way comments are set in this file prevented the extension for
SoundFile from working, most likely because of the */ usages in the code
itself (SC 3.12.1, SCIDE, Ubuntu Studio 20.04)

Signed-off-by: Stefan Nussbaumer <st9fan@gmail.com>